### PR TITLE
Improve testing experience with makefile commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,13 +16,6 @@ test: test-unit test-behavior ## launch full test suite
 test-unit: ## launch unit tests
 	./vendor/bin/atoum
 test-behavior: docker-up ## launch behavior tests
-	@/bin/echo -n "Waiting for elasticsearch to be ready ..."
-	n=`curl --write-out %{http_code} --silent --output /dev/null http://localhost:9200/_cluster/health`; \
-    while [ $${n} -ne 200 ] ; do \
-		/bin/echo -n "." ; \
-        n=`curl --write-out %{http_code} --silent --output /dev/null http://localhost:9200/_cluster/health`; \
-	done; \
-	echo " READY !" ; \
-	true
+	./scripts/waitForElastic.sh
 	./vendor/bin/behat
 	make docker-down

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,21 @@
+# Help
+.SILENT:
+.PHONY: help
+
+help: ## Display this help
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
+
+# Docker
+docker-up: ## start docker elasticsearch server
+	docker-compose up -d elasticsearch
+docker-down: ## start docker elasticsearch server
+	docker-compose down
+
+# Testing
+test: test-unit test-behavior ## launch full test suite
+test-unit: ## launch unit tests
+	./vendor/bin/atoum
+test-behavior: docker-up ## launch behavior tests
+	sleep 10
+	./vendor/bin/behat
+	make docker-down

--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,13 @@ test: test-unit test-behavior ## launch full test suite
 test-unit: ## launch unit tests
 	./vendor/bin/atoum
 test-behavior: docker-up ## launch behavior tests
-	sleep 10
+	@/bin/echo -n "Waiting for elasticsearch to be ready ..."
+	n=`curl --write-out %{http_code} --silent --output /dev/null http://localhost:9200/_cluster/health`; \
+    while [ $${n} -ne 200 ] ; do \
+		/bin/echo -n "." ; \
+        n=`curl --write-out %{http_code} --silent --output /dev/null http://localhost:9200/_cluster/health`; \
+	done; \
+	echo " READY !" ; \
+	true
 	./vendor/bin/behat
 	make docker-down

--- a/README.md
+++ b/README.md
@@ -154,6 +154,16 @@ services:
 
 Then you'll only have to work with the `myapp.search.object_indexer` and `myapp.search.query_executor` services.
 
+## Testing
+
+A testing environment is provided using a dockerized version of elasticsearch.
+
+Testing is done using the [Atoum](http://atoum.org/) framework for unit testing and the [Behat](http://behat.org/en/latest/) framework for behavior testing.
+
+A `Makefile` provide useful commands for testing, so you can run the full test suite by running :
+```sh
+$ make test
+```
 
 ## License
 

--- a/scripts/waitForElastic.sh
+++ b/scripts/waitForElastic.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+echo -n "Waiting for elasticsearch to be ready ..."
+
+code=`curl --write-out %{http_code} --silent --output /dev/null http://localhost:9200/_cluster/health`;
+iteration=0;
+
+while [ $code -ne 200 ] ; do
+    sleep 1;
+    /bin/echo -n ".";
+
+    code=`curl --write-out %{http_code} --silent --output /dev/null http://localhost:9200/_cluster/health`;
+    iteration=`expr $iteration + 1`;
+
+    if [ $iteration -gt 180 ]; then
+        echo "TIMEOUT !"
+        exit 1;
+    fi
+done;
+
+echo " READY !" ;
+exit 0;


### PR DESCRIPTION
I added a makefile running the full testing suite with a dockerized ES server and completed makefile because testing was too much implicit