### PR TITLE
Added a way to automatically keep limit when using a resultTransformer

### DIFF
--- a/src/Index.php
+++ b/src/Index.php
@@ -96,7 +96,7 @@ class Index
 
         if ($resultTransformer) {
             $result = $resultTransformer->formatResult($result);
-            if (!$result->getLimit()) {
+            if ($result->getLimit() === null) {
                 // keep limit if it has not been set by the transformer
                 $result->setLimit($limit);
             }

--- a/src/Index.php
+++ b/src/Index.php
@@ -96,6 +96,10 @@ class Index
 
         if ($resultTransformer) {
             $result = $resultTransformer->formatResult($result);
+            if (!$result->getLimit()) {
+                // keep limit if it has not been set by the transformer
+                $result->setLimit($limit);
+            }
         }
 
         return $result;

--- a/src/Query/Result.php
+++ b/src/Query/Result.php
@@ -107,6 +107,16 @@ class Result
         return $this->aggregations;
     }
 
+    public function getLimit()
+    {
+        return $this->limit;
+    }
+
+    public function setLimit(int $limit = null)
+    {
+        $this->limit = $limit;
+    }
+
     /**
      * @param int $limit the number of hits per request
      * @return int


### PR DESCRIPTION
If limit has been set, it should stay on the result returned by the result Transformer.

I added a check, allowing the resultTransformer to alter limit if needed