### PR TITLE
Function score modes

### DIFF
--- a/src/Query/QueryBuilder.php
+++ b/src/Query/QueryBuilder.php
@@ -6,6 +6,7 @@ use Novaway\ElasticsearchClient\Aggregation\Aggregation;
 use Novaway\ElasticsearchClient\Clause;
 use Novaway\ElasticsearchClient\Filter\Filter;
 use Novaway\ElasticsearchClient\Score\FunctionScore;
+use Novaway\ElasticsearchClient\Score\FunctionScoreOptions;
 use Novaway\ElasticsearchClient\Script\ScriptField;
 use Novaway\ElasticsearchClient\Score\ScriptScore;
 
@@ -37,6 +38,8 @@ class QueryBuilder
     protected $scriptFieldCollection;
     /** @var null|ScriptScore */
     protected $scriptScore;
+    /** @var null|FunctionScoreOptions */
+    protected $functionsScoreOptions;
 
     public function __construct($offset = self::DEFAULT_OFFSET, $limit = self::DEFAULT_LIMIT, $minScore = self::DEFAULT_MIN_SCORE)
     {
@@ -142,6 +145,7 @@ class QueryBuilder
     /**
      * @param $field
      * @param $value
+     * @param string $combiningFactor
      *
      * @return QueryBuilder
      */
@@ -230,6 +234,19 @@ class QueryBuilder
     }
 
     /**
+     * @return null|FunctionScoreOptions
+     */
+    public function getFunctionsScoreOptions()
+    {
+        return $this->functionsScoreOptions;
+    }
+
+    public function setFunctionsScoreOptions(FunctionScoreOptions $functionsScoreOptions)
+    {
+        $this->functionsScoreOptions = $functionsScoreOptions;
+    }
+
+    /**
      * @return array
      */
     public function getQueryBody(): array
@@ -251,7 +268,9 @@ class QueryBuilder
             $query = $queryBody['query'];
             unset($queryBody['query']['bool']);
 
-            $function = ['query' => $query];
+            $function = $this->getFunctionsScoreOptions() ? $this->getFunctionsScoreOptions()->formatForQuery() : [];
+
+            $function += ['query' => $query];
 
             foreach ($this->functionScoreCollection as $functionScore) {
                 $function['functions'][] = $functionScore->formatForQuery();

--- a/src/Score/BoostMode.php
+++ b/src/Score/BoostMode.php
@@ -1,0 +1,24 @@
+<?php
+
+
+namespace Novaway\ElasticsearchClient\Score;
+
+
+class BoostMode
+{
+    const MULTIPLY = 'multiply';
+    const REPLACE = 'replace';
+    const SUM = 'sum';
+    const AVG = 'avg';
+    const MAX = 'max';
+    const MIN = 'min';
+
+    public static $available = [
+        self::MULTIPLY,
+        self::REPLACE,
+        self::SUM,
+        self::AVG,
+        self::MAX,
+        self::MIN
+    ];
+}

--- a/src/Score/FunctionScoreOptions.php
+++ b/src/Score/FunctionScoreOptions.php
@@ -1,0 +1,57 @@
+<?php
+
+
+namespace Novaway\ElasticsearchClient\Score;
+
+
+class FunctionScoreOptions
+{
+    /** @var string */
+    protected $scoreMode;
+    /** @var string */
+    protected $boostMode;
+    /** @var int */
+    protected $boost;
+    /** @var int */
+    protected $maxBoost;
+    /** @var int */
+    protected $minBoost;
+
+    public function __construct(string $scoreMode = null, string $boostMode = BoostMode::REPLACE, int $boost = null, int $maxBoost = null, int $minBoost = null)
+    {
+        if ($scoreMode && !in_array($scoreMode, ScoreMode::$available)) {
+            throw new \InvalidArgumentException('$scoreMode should be one of ' . implode(",", ScoreMode::$available) . ". $scoreMode given");
+        }
+        if ($boostMode && !in_array($boostMode, BoostMode::$available)) {
+            throw new \InvalidArgumentException('$boostMode should be one of ' . implode(",", BoostMode::$available) . ". $boostMode given");
+        }
+
+        $this->scoreMode = $scoreMode;
+        $this->boostMode = $boostMode;
+        $this->boost = $boost;
+        $this->maxBoost = $maxBoost;
+        $this->minBoost = $minBoost;
+    }
+
+
+    public function formatForQuery(): array
+    {
+        $res = [];
+        if (null !== $this->scoreMode) {
+            $res['score_mode'] = $this->scoreMode;
+        }
+        if (null !== $this->boostMode) {
+            $res['boost_mode'] = $this->boostMode;
+        }
+        if (null !== $this->boost) {
+            $res['boost'] = $this->boost;
+        }
+        if (null !== $this->maxBoost) {
+            $res['max_boost'] = $this->maxBoost;
+        }
+        if (null !== $this->maxBoost) {
+            $res['min_boost'] = $this->minBoost;
+        }
+        return $res;
+    }
+}

--- a/src/Score/FunctionScoreOptions.php
+++ b/src/Score/FunctionScoreOptions.php
@@ -4,6 +4,8 @@
 namespace Novaway\ElasticsearchClient\Score;
 
 
+use Webmozart\Assert\Assert;
+
 class FunctionScoreOptions
 {
     /** @var string */
@@ -19,11 +21,11 @@ class FunctionScoreOptions
 
     public function __construct(string $scoreMode = null, string $boostMode = BoostMode::REPLACE, int $boost = null, int $maxBoost = null, int $minBoost = null)
     {
-        if ($scoreMode && !in_array($scoreMode, ScoreMode::$available)) {
-            throw new \InvalidArgumentException('$scoreMode should be one of ' . implode(",", ScoreMode::$available) . ". $scoreMode given");
+        if ($scoreMode) {
+            Assert::oneOf($scoreMode, ScoreMode::$available);
         }
-        if ($boostMode && !in_array($boostMode, BoostMode::$available)) {
-            throw new \InvalidArgumentException('$boostMode should be one of ' . implode(",", BoostMode::$available) . ". $boostMode given");
+        if ($boostMode) {
+            Assert::oneOf($boostMode, BoostMode::$available);
         }
 
         $this->scoreMode = $scoreMode;

--- a/src/Score/ScoreMode.php
+++ b/src/Score/ScoreMode.php
@@ -1,0 +1,25 @@
+<?php
+
+
+namespace Novaway\ElasticsearchClient\Score;
+
+
+class ScoreMode
+{
+    const MULTIPLY = 'multiply';
+    const FIRST = 'first';
+    const SUM = 'sum';
+    const AVG = 'avg';
+    const MAX = 'max';
+    const MIN = 'min';
+
+
+    public static $available = [
+        self::MULTIPLY,
+        self::FIRST,
+        self::SUM,
+        self::AVG,
+        self::MAX,
+        self::MIN
+    ];
+}

--- a/test/functional/bootstrap/FeatureContext.php
+++ b/test/functional/bootstrap/FeatureContext.php
@@ -26,6 +26,7 @@ use Novaway\ElasticsearchClient\Query\MatchQuery;
 use Novaway\ElasticsearchClient\Query\CombiningFactor;
 use Novaway\ElasticsearchClient\QueryExecutor;
 use Novaway\ElasticsearchClient\Score\DecayFunctionScore;
+use Novaway\ElasticsearchClient\Score\FunctionScoreOptions;
 use Novaway\ElasticsearchClient\Score\RandomScore;
 use Novaway\ElasticsearchClient\Score\ScriptScore;
 use Novaway\ElasticsearchClient\Script\ScriptField;
@@ -505,6 +506,23 @@ class FeatureContext implements Context
         }
     }
 
+    /**
+     * @Given I set the function score options as :
+     */
+    public function iSetTheFunctionScoreOptionsAs(TableNode $queryTable)
+    {
+        $this->queryBuilder = $this->queryBuilder ?? QueryBuilder::createNew();
+        $queryHash = $queryTable->getHash();
+        $queryRow = reset($queryHash);
+        $this->queryBuilder->setFunctionsScoreOptions(new FunctionScoreOptions(
+            $queryRow['scoreMode'] ?? null,
+            $queryRow['boostMode'] ?? null,
+            $queryRow['boost'] ?? null,
+            $queryRow['maxBoost'] ?? null,
+            $queryRow['minBoost'] ?? null
+        ));
+    }
+    
     /**
      * @When I create nested index and populate it on :indexName
      */

--- a/test/functional/features/search.feature
+++ b/test/functional/features/search.feature
@@ -302,3 +302,27 @@ Feature: Search on index
             |  doc['age'].value * params.multiplier     | {"multiplier":3}        | painless |
         When I execute it on the index named "my_index" for type "_doc"
         Then the result n° "0" should contain field "_score" equaling "99"
+
+    Scenario: Function score options
+        Given I build a query matching :
+            | field       | value  | condition |
+            | id          | 1      | must      |
+        And I build a script score function with :
+            | source  | params    | lang     |
+            |  doc['age'].value * params.multiplier     | {"multiplier":3}        | painless |
+            |  doc['age'].value * params.multiplier     | {"multiplier":5}        | painless |
+        And I set the function score options as :
+            | scoreMode  | boostMode |
+            |  sum       | replace   |
+        When I execute it on the index named "my_index" for type "_doc"
+        Then the result n° "0" should contain field "_score" equaling "264"
+        And I set the function score options as :
+            | scoreMode  | boostMode |
+            |  avg       | replace   |
+        When I execute it on the index named "my_index" for type "_doc"
+        Then the result n° "0" should contain field "_score" equaling "132"
+        And I set the function score options as :
+            | scoreMode  | boostMode |
+            |  min       | replace   |
+        When I execute it on the index named "my_index" for type "_doc"
+        Then the result n° "0" should contain field "_score" equaling "99"


### PR DESCRIPTION
As seen [here](https://www.elastic.co/guide/en/elasticsearch/reference/6.0/query-dsl-function-score-query.html#query-dsl-function-score-query), BoostMode and ScoreMode are necessary to manipulate the interactions of multiple function scores.

Therefore I added a FunctionScoreOptions to handle every possible functione score option in the QueryBuilder