### PR TITLE
Added a way to pass options to BoolQuery

### DIFF
--- a/src/Query/Compound/BoolQuery.php
+++ b/src/Query/Compound/BoolQuery.php
@@ -16,12 +16,15 @@ class BoolQuery implements Query
     private $combiningFactor;
     /** @var Clause[] */
     private $clauses;
+    /** @var array */
+    private $options;
 
-    public function __construct(string $combiningFactor = CombiningFactor::MUST)
+    public function __construct(string $combiningFactor = CombiningFactor::MUST, array $options = [])
     {
         Assert::oneOf($combiningFactor, CombiningFactor::toArray());
         $this->combiningFactor = $combiningFactor;
         $this->clauses = [];
+        $this->options = $options;
     }
 
     public function getCombiningFactor(): string
@@ -36,7 +39,7 @@ class BoolQuery implements Query
 
     public function formatForQuery(): array
     {
-        $res = [];
+        $res = $this->options;
         foreach ($this->clauses as $clause) {
             $res[$clause->getCombiningFactor()][] = $clause->formatForQuery();
         }


### PR DESCRIPTION
It is possible to add a `boost` or `minimum_should_match` to a BoolQuery 
See https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-bool-query.html