### PR TITLE
Refacto query filters

### DIFF
--- a/src/Filter/ExistsFilter.php
+++ b/src/Filter/ExistsFilter.php
@@ -4,34 +4,11 @@
 namespace Novaway\ElasticsearchClient\Filter;
 
 
-use Novaway\ElasticsearchClient\Query\CombiningFactor;
-use Webmozart\Assert\Assert;
+use Novaway\ElasticsearchClient\Query\Term\ExistsQuery;
 
-class ExistsFilter implements Filter
+/**
+ * @deprecated use Novaway\ElasticsearchClient\Query\Term\ExistsQuery instead
+ */
+class ExistsFilter extends ExistsQuery
 {
-    /** @var string */
-    protected $property;
-    /** @var string */
-    private $combiningFactor;
-
-    public function __construct(string $property, $combiningFactor = CombiningFactor::FILTER)
-    {
-        Assert::oneOf($combiningFactor, CombiningFactor::toArray());
-        $this->property = $property;
-        $this->combiningFactor = $combiningFactor;
-    }
-
-    public function getCombiningFactor(): string
-    {
-        return $this->combiningFactor;
-    }
-
-    /**
-     * @inheritDoc
-     */
-    public function formatForQuery(): array
-    {
-        return ['exists' => [ 'field' => $this->property]];
-    }
-
 }

--- a/src/Filter/GeoDistanceFilter.php
+++ b/src/Filter/GeoDistanceFilter.php
@@ -2,72 +2,11 @@
 
 namespace Novaway\ElasticsearchClient\Filter;
 
-use Novaway\ElasticsearchClient\Query\CombiningFactor;
-use Novaway\ElasticsearchClient\Query\Geo\DistanceUnits;
-use Webmozart\Assert\Assert;
+use Novaway\ElasticsearchClient\Query\Geo\GeoDistanceQuery;
 
-class GeoDistanceFilter implements Filter
+/**
+ * @deprecated use Novaway\ElasticsearchClient\Query\Geo\GeoDistanceQuery instead
+ */
+class GeoDistanceFilter extends GeoDistanceQuery
 {
-    /** @var string */
-    private $property;
-    /** @var float */
-    private $latitude;
-    /** @var float */
-    private $longitude;
-    /** @var float */
-    private $distance;
-    /** @var string */
-    private $combiningFactor;
-    /** @var string */
-    private $unit;
-    /** @var array */
-    private $options;
-
-    /**
-     * GeoDistanceFilter constructor.
-     * @param string $property
-     * @param float $latitude
-     * @param float $longitude
-     * @param float $distance
-     * @param string $combiningFactor
-     * @param string $unit Should be one of those https://www.elastic.co/guide/en/elasticsearch/reference/2.3/common-options.html#distance-units
-     * @param array $options Used to pass options from https://www.elastic.co/guide/en/elasticsearch/reference/2.3/query-dsl-geo-distance-query.html#_options_4
-     */
-    public function __construct(string $property, float $latitude, float $longitude, float $distance, string $combiningFactor = CombiningFactor::FILTER, string $unit = DistanceUnits::KM, array $options = [])
-    {
-        Assert::oneOf($combiningFactor, CombiningFactor::toArray());
-        Assert::oneOf($unit, DistanceUnits::toArray());
-
-        $this->property  = $property;
-        $this->latitude  = $latitude;
-        $this->longitude = $longitude;
-        $this->distance  = $distance;
-        $this->combiningFactor = $combiningFactor;
-        $this->unit = $unit;
-        $this->options = $options;
-    }
-
-    /**
-     * @return string
-     */
-    public function getCombiningFactor(): string
-    {
-        return $this->combiningFactor;
-    }
-
-    /**
-     * @inheritdoc
-     */
-    public function formatForQuery(): array
-    {
-        return [
-            'geo_distance' => array_merge([
-                'distance'     => sprintf('%01.2f%s', $this->distance, $this->unit),
-                $this->property => [
-                    'lat' => $this->latitude,
-                    'lon' => $this->longitude
-                ]
-            ], $this->options)
-        ];
-    }
 }

--- a/src/Filter/InArrayFilter.php
+++ b/src/Filter/InArrayFilter.php
@@ -2,46 +2,11 @@
 
 namespace Novaway\ElasticsearchClient\Filter;
 
-use Novaway\ElasticsearchClient\Query\CombiningFactor;
-use Webmozart\Assert\Assert;
+use Novaway\ElasticsearchClient\Query\Term\InArrayQuery;
 
-class InArrayFilter implements Filter
+/**
+ * @deprecated use Novaway\ElasticsearchClient\Query\Term\InArrayQuery instead
+ */
+class InArrayFilter extends InArrayQuery
 {
-    /** @var string */
-    private $property;
-    /** @var array */
-    private $values;
-    /** @var string */
-    private $combiningFactor;
-
-    public function __construct(string $property, array $values, string $combiningFactor = CombiningFactor::FILTER)
-    {
-        Assert::oneOf($combiningFactor, CombiningFactor::toArray());
-        $this->property = $property;
-        $this->values = $values;
-        $this->combiningFactor = $combiningFactor;
-    }
-
-    /**
-     * @return string
-     */
-    public function getCombiningFactor(): string
-    {
-        return $this->combiningFactor;
-    }
-
-    /**
-     * @inheritDoc
-     */
-    public function formatForQuery(): array
-    {
-        return [
-            'bool' => [
-                'should' => array_map(function ($value) {
-                    $matchFilter = new TermFilter($this->property, $value);
-                    return $matchFilter->formatForQuery();
-                }, $this->values)
-            ]
-        ];
-    }
 }

--- a/src/Filter/NestedFilter.php
+++ b/src/Filter/NestedFilter.php
@@ -4,49 +4,11 @@
 namespace Novaway\ElasticsearchClient\Filter;
 
 
-use Novaway\ElasticsearchClient\Clause;
-use Novaway\ElasticsearchClient\Query\CombiningFactor;
-use Webmozart\Assert\Assert;
+use Novaway\ElasticsearchClient\Query\Joining\NestedQuery;
 
-class NestedFilter implements Filter
+/**
+ * @deprecated use Novaway\ElasticsearchClient\Query\Joining\NestedQuery instead
+ */
+class NestedFilter extends NestedQuery
 {
-    /** @var string */
-    protected $property;
-    /** @var Clause[] */
-    protected $clauses;
-    /** @var string */
-    private $combiningFactor;
-
-    public function __construct(string $property, $combiningFactor = CombiningFactor::FILTER)
-    {
-        Assert::oneOf($combiningFactor, CombiningFactor::toArray());
-        $this->property = $property;
-        $this->combiningFactor = $combiningFactor;
-        $this->clauses = [];
-    }
-
-    public function addClause(Clause $clause)
-    {
-        $this->clauses[] = $clause;
-    }
-
-    public function formatForQuery(): array
-    {
-        return ['nested' => [
-            'path' => $this->property,
-            'query' => [
-                'bool' => [
-                    'filter' => array_map(function(Clause $clause) {
-                        return $clause->formatForQuery();
-                    }, $this->clauses)
-                ]
-            ]
-        ]];
-    }
-
-    public function getCombiningFactor(): string
-    {
-        return $this->combiningFactor;
-    }
-
 }

--- a/src/Filter/RangeFilter.php
+++ b/src/Filter/RangeFilter.php
@@ -2,75 +2,11 @@
 
 namespace Novaway\ElasticsearchClient\Filter;
 
-use Novaway\ElasticsearchClient\Query\CombiningFactor;
-use Webmozart\Assert\Assert;
+use Novaway\ElasticsearchClient\Query\Term\RangeQuery;
 
-class RangeFilter implements Filter
+/**
+ * @deprecated use Novaway\ElasticsearchClient\Query\Term\RangeQuery instead
+ */
+class RangeFilter extends RangeQuery
 {
-    const GREATER_THAN_OPERATOR = 'gt';
-    const GREATER_THAN_OR_EQUAL_OPERATOR = 'gte';
-    const LESS_THAN_OPERATOR = 'lt';
-    const LESS_THAN_OR_EQUAL_OPERATOR = 'lte';
-
-    /** @var string */
-    private $property;
-    /** @var mixed */
-    private $value;
-    /** @var array */
-    private $operator;
-    /** @var string */
-    private $combiningFactor;
-
-    /**
-     * RangeFilter constructor.
-     * @param string $property
-     * @param $value
-     * @param $operator
-     */
-    public function __construct(string $property, $value, $operator, string $combiningFactor = CombiningFactor::FILTER)
-    {
-        Assert::oneOf($combiningFactor, CombiningFactor::toArray());
-
-        if(is_array($value) && !is_array($operator)) {
-            throw new \InvalidArgumentException("Operator should be an array when range filter value is an array");
-        }
-        if(!is_array($value) && is_array($operator)) {
-            throw new \InvalidArgumentException("Operator can't be an array if range filter is not an array");
-        }
-        if(is_array($value) && is_array($operator) && count($value) !== count($operator)) {
-            throw new \InvalidArgumentException("Number of provided operator does not match number of provided values");
-        }
-
-        $this->property = $property;
-        $this->value = is_array($value) ? $value : [$value];
-        $this->operator = is_array($operator) ? $operator : [$operator];
-        $this->combiningFactor = $combiningFactor;
-    }
-
-    /**
-     * @return string
-     */
-    public function getCombiningFactor(): string
-    {
-        return $this->combiningFactor;
-    }
-
-    /**
-     * @inheritDoc
-     */
-    public function formatForQuery(): array
-    {
-        $rangeConditions = [];
-
-        $valueCount = count($this->value);
-        for ($i = 0; $i < $valueCount; $i++){
-            $rangeConditions[] = [$this->operator[$i] => $this->value[$i]];
-        }
-
-        return [
-            'range' => [
-                $this->property => $rangeConditions
-            ]
-        ];
-    }
 }

--- a/src/Filter/TermFilter.php
+++ b/src/Filter/TermFilter.php
@@ -2,50 +2,12 @@
 
 namespace Novaway\ElasticsearchClient\Filter;
 
-use Novaway\ElasticsearchClient\Query\CombiningFactor;
-use Webmozart\Assert\Assert;
+use Novaway\ElasticsearchClient\Filter\Term\TermQuery;
 
-class TermFilter implements Filter
+/**
+ * @deprecated use Novaway\ElasticsearchClient\Filter\Term\TermQuery instead
+ */
+class TermFilter extends TermQuery
 {
-    /** @var string */
-    private $property;
-    /** @var string */
-    private $value;
-    /** @var string */
-    private $combiningFactor;
-    /** @var float */
-    private $boost;
-
-    public function __construct(string $property, $value, string $combiningFactor = CombiningFactor::FILTER, float $boost = 1)
-    {
-        Assert::oneOf($combiningFactor, CombiningFactor::toArray());
-        $this->property = $property;
-        $this->value = $value;
-        $this->combiningFactor = $combiningFactor;
-        $this->boost = $boost;
-    }
-
-    /**
-     * @return string
-     */
-    public function getCombiningFactor(): string
-    {
-        return $this->combiningFactor;
-    }
-
-    /**
-     * @inheritDoc
-     */
-    public function formatForQuery(): array
-    {
-        return [
-            'term' => [
-                $this->property =>  [
-                    'value' => $this->value,
-                    'boost' => $this->boost
-                ]
-            ]
-        ];
-    }
 }
 

--- a/src/Filter/TermFilter.php
+++ b/src/Filter/TermFilter.php
@@ -2,7 +2,7 @@
 
 namespace Novaway\ElasticsearchClient\Filter;
 
-use Novaway\ElasticsearchClient\Filter\Term\TermQuery;
+use Novaway\ElasticsearchClient\Query\Term\TermQuery;
 
 /**
  * @deprecated use Novaway\ElasticsearchClient\Filter\Term\TermQuery instead

--- a/src/Query/BoolQuery.php
+++ b/src/Query/BoolQuery.php
@@ -3,43 +3,9 @@
 
 namespace Novaway\ElasticsearchClient\Query;
 
-
-use Novaway\ElasticsearchClient\Clause;
-use Webmozart\Assert\Assert;
-
-class BoolQuery implements Query
+/**
+ * @deprecated use Novaway\ElasticsearchClient\Query\Compound\BoolQuery instead
+ */
+class BoolQuery extends \Novaway\ElasticsearchClient\Query\Compound\BoolQuery
 {
-
-    /** @var string */
-    private $combiningFactor;
-    /** @var Clause[] */
-    private $clauses;
-
-    public function __construct(string $combiningFactor = CombiningFactor::MUST)
-    {
-        Assert::oneOf($combiningFactor, CombiningFactor::toArray());
-        $this->combiningFactor = $combiningFactor;
-        $this->clauses = [];
-    }
-
-    public function getCombiningFactor(): string
-    {
-        return $this->combiningFactor;
-    }
-
-    public function addClause(Clause $clause)
-    {
-        $this->clauses[] = $clause;
-    }
-    public function formatForQuery(): array
-    {
-        $res = [];
-        foreach ($this->clauses as $clause) {
-            $res[$clause->getCombiningFactor()][] = $clause->formatForQuery();
-        }
-
-        return ['bool' => $res];
-    }
-
-
 }

--- a/src/Query/Compound/BoolQuery.php
+++ b/src/Query/Compound/BoolQuery.php
@@ -1,0 +1,48 @@
+<?php
+
+
+namespace Novaway\ElasticsearchClient\Query\Compound;
+
+
+use Novaway\ElasticsearchClient\Clause;
+use Novaway\ElasticsearchClient\Query\CombiningFactor;
+use Novaway\ElasticsearchClient\Query\Query;
+use Webmozart\Assert\Assert;
+
+class BoolQuery implements Query
+{
+
+    /** @var string */
+    private $combiningFactor;
+    /** @var Clause[] */
+    private $clauses;
+
+    public function __construct(string $combiningFactor = CombiningFactor::MUST)
+    {
+        Assert::oneOf($combiningFactor, CombiningFactor::toArray());
+        $this->combiningFactor = $combiningFactor;
+        $this->clauses = [];
+    }
+
+    public function getCombiningFactor(): string
+    {
+        return $this->combiningFactor;
+    }
+
+    public function addClause(Clause $clause)
+    {
+        $this->clauses[] = $clause;
+    }
+
+    public function formatForQuery(): array
+    {
+        $res = [];
+        foreach ($this->clauses as $clause) {
+            $res[$clause->getCombiningFactor()][] = $clause->formatForQuery();
+        }
+
+        return ['bool' => $res];
+    }
+
+
+}

--- a/src/Query/Compound/FunctionScore.php
+++ b/src/Query/Compound/FunctionScore.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Novaway\ElasticsearchClient\Query\Compound;
+
+interface FunctionScore
+{
+    /**
+     * Return a JSON formatted representation of the clause, tu use in elasticsearch
+     *
+     * @return array
+     */
+    public function formatForQuery(): array;
+}

--- a/src/Query/FullText/MatchQuery.php
+++ b/src/Query/FullText/MatchQuery.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Novaway\ElasticsearchClient\Query\FullText;
+
+//https://www.elastic.co/guide/en/elasticsearch/reference/5.6/query-dsl-match-query.html
+use Novaway\ElasticsearchClient\Query\Query;
+use Webmozart\Assert\Assert;
+
+
+class MatchQuery implements Query
+{
+    /** @var string */
+    private $combiningFactor;
+    /** @var string */
+    private $field;
+    /** @var mixed */
+    private $value;
+    /** @var array  */
+    private $options;
+
+    public function __construct(string $field, $value, string $combiningFactor = CombiningFactor::MUST, array $options = ['operator' => 'AND'])
+    {
+        Assert::oneOf($combiningFactor, CombiningFactor::toArray());
+        $this->field = $field;
+        $this->value = $value;
+        $this->combiningFactor = $combiningFactor;
+        $this->options = $options;
+    }
+
+    /**
+     * @return string
+     */
+    public function getCombiningFactor(): string
+    {
+        return $this->combiningFactor;
+    }
+
+    /**
+     * @return string
+     */
+    public function getField(): string
+    {
+        return $this->field;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getValue()
+    {
+        return $this->value;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function formatForQuery(): array
+    {
+        return [
+                'match' => [
+                    $this->getField() =>  array_merge([
+                        'query' => $this->getValue()
+                    ], $this->options)
+                ]
+            ];
+    }
+
+
+}

--- a/src/Query/FullText/MultiMatchQuery.php
+++ b/src/Query/FullText/MultiMatchQuery.php
@@ -1,0 +1,67 @@
+<?php
+
+
+namespace Novaway\ElasticsearchClient\Query\FullText;
+
+
+use Novaway\ElasticsearchClient\Query\BoostableField;
+use Novaway\ElasticsearchClient\Query\CombiningFactor;
+use Novaway\ElasticsearchClient\Query\Query;
+use Webmozart\Assert\Assert;
+
+class MultiMatchQuery implements Query
+{
+    const BEST_FIELDS = 'best_fields';
+    const MOST_FIELDS = 'most_fields';
+    const CROSS_FIELDS = 'cross_fields';
+    const PHRASE = 'phrase';
+    const PHRASE_PREFIX = 'phrase_prefix';
+    /** @var string */
+    private $value;
+    /** @var string[]|BoostableField[] */
+    private $fields;
+    /** @var array */
+    private $options;
+    /** @var string */
+    private $combiningFactor;
+
+    /**
+     * @param string $value the query value to search for
+     * @param array $fields the fields to search for. Should either contain strings or BoostableField
+     * @param string $combiningFactor the combining factor
+     * @param array $options additional options
+     */
+    public function __construct(string $value, array $fields, string $combiningFactor = CombiningFactor::SHOULD,array $options = [])
+    {
+        Assert::oneOf($combiningFactor, CombiningFactor::toArray());
+        $fields = array_map(function($field) {
+            if (!($field instanceof BoostableField || is_string($field))) {
+                throw new \Exception('$fields array should either contain strings or BoostableField');
+            };
+            // if the field is a string, the cast doesn't do anything
+            // if the field is a BoostableField, it willl be cast as string using the __toString method
+            return (string)$field;
+        }, $fields);
+
+        $this->value = $value;
+        $this->fields = $fields;
+        $this->options = $options;
+        $this->combiningFactor = $combiningFactor;
+    }
+    
+    public function formatForQuery(): array
+    {
+        return [
+            'multi_match' =>
+                array_merge([
+                    'query' => $this->value,
+                    'fields' => $this->fields
+                ], $this->options)
+        ];
+    }
+
+    public function getCombiningFactor(): string
+    {
+        return $this->combiningFactor;
+    }
+}

--- a/src/Query/Geo/GeoDistanceQuery.php
+++ b/src/Query/Geo/GeoDistanceQuery.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace Novaway\ElasticsearchClient\Query\Geo;
+
+use Novaway\ElasticsearchClient\Filter\Filter;
+use Novaway\ElasticsearchClient\Query\CombiningFactor;
+use Novaway\ElasticsearchClient\Query\Query;
+use Webmozart\Assert\Assert;
+
+class GeoDistanceQuery implements Query, Filter
+{
+    /** @var string */
+    private $property;
+    /** @var float */
+    private $latitude;
+    /** @var float */
+    private $longitude;
+    /** @var float */
+    private $distance;
+    /** @var string */
+    private $combiningFactor;
+    /** @var string */
+    private $unit;
+    /** @var array */
+    private $options;
+
+    /**
+     * GeoDistanceFilter constructor.
+     * @param string $property
+     * @param float $latitude
+     * @param float $longitude
+     * @param float $distance
+     * @param string $combiningFactor
+     * @param string $unit Should be one of those https://www.elastic.co/guide/en/elasticsearch/reference/2.3/common-options.html#distance-units
+     * @param array $options Used to pass options from https://www.elastic.co/guide/en/elasticsearch/reference/2.3/query-dsl-geo-distance-query.html#_options_4
+     */
+    public function __construct(string $property, float $latitude, float $longitude, float $distance, string $combiningFactor = CombiningFactor::FILTER, string $unit = DistanceUnits::KM, array $options = [])
+    {
+        Assert::oneOf($combiningFactor, CombiningFactor::toArray());
+        Assert::oneOf($unit, DistanceUnits::toArray());
+
+        $this->property  = $property;
+        $this->latitude  = $latitude;
+        $this->longitude = $longitude;
+        $this->distance  = $distance;
+        $this->combiningFactor = $combiningFactor;
+        $this->unit = $unit;
+        $this->options = $options;
+    }
+
+    /**
+     * @return string
+     */
+    public function getCombiningFactor(): string
+    {
+        return $this->combiningFactor;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function formatForQuery(): array
+    {
+        return [
+            'geo_distance' => array_merge([
+                'distance'     => sprintf('%01.2f%s', $this->distance, $this->unit),
+                $this->property => [
+                    'lat' => $this->latitude,
+                    'lon' => $this->longitude
+                ]
+            ], $this->options)
+        ];
+    }
+}

--- a/src/Query/Joining/NestedQuery.php
+++ b/src/Query/Joining/NestedQuery.php
@@ -1,0 +1,54 @@
+<?php
+
+
+namespace Novaway\ElasticsearchClient\Query\Joining;
+
+
+use Novaway\ElasticsearchClient\Clause;
+use Novaway\ElasticsearchClient\Filter\Filter;
+use Novaway\ElasticsearchClient\Query\CombiningFactor;
+use Novaway\ElasticsearchClient\Query\Query;
+use Webmozart\Assert\Assert;
+
+class NestedQuery implements Filter, Query
+{
+    /** @var string */
+    protected $property;
+    /** @var Clause[] */
+    protected $clauses;
+    /** @var string */
+    private $combiningFactor;
+
+    public function __construct(string $property, $combiningFactor = CombiningFactor::FILTER)
+    {
+        Assert::oneOf($combiningFactor, CombiningFactor::toArray());
+        $this->property = $property;
+        $this->combiningFactor = $combiningFactor;
+        $this->clauses = [];
+    }
+
+    public function addClause(Clause $clause)
+    {
+        $this->clauses[] = $clause;
+    }
+
+    public function formatForQuery(): array
+    {
+        return ['nested' => [
+            'path' => $this->property,
+            'query' => [
+                'bool' => [
+                    'filter' => array_map(function(Clause $clause) {
+                        return $clause->formatForQuery();
+                    }, $this->clauses)
+                ]
+            ]
+        ]];
+    }
+
+    public function getCombiningFactor(): string
+    {
+        return $this->combiningFactor;
+    }
+
+}

--- a/src/Query/MatchQuery.php
+++ b/src/Query/MatchQuery.php
@@ -2,8 +2,6 @@
 
 namespace Novaway\ElasticsearchClient\Query;
 
-//https://www.elastic.co/guide/en/elasticsearch/reference/5.6/query-dsl-match-query.html
-use Webmozart\Assert\Assert;
 
 /**
  * @deprecated use Novaway\ElasticsearchClient\Query\FullText\MatchQuery instead

--- a/src/Query/MatchQuery.php
+++ b/src/Query/MatchQuery.php
@@ -5,63 +5,9 @@ namespace Novaway\ElasticsearchClient\Query;
 //https://www.elastic.co/guide/en/elasticsearch/reference/5.6/query-dsl-match-query.html
 use Webmozart\Assert\Assert;
 
-class MatchQuery implements Query
+/**
+ * @deprecated use Novaway\ElasticsearchClient\Query\FullText\MatchQuery instead
+ */
+class MatchQuery extends \Novaway\ElasticsearchClient\Query\FullText\MatchQuery
 {
-    /** @var string */
-    private $combiningFactor;
-    /** @var string */
-    private $field;
-    /** @var mixed */
-    private $value;
-    /** @var array  */
-    private $options;
-
-    public function __construct(string $field, $value, string $combiningFactor = CombiningFactor::MUST, array $options = ['operator' => 'AND'])
-    {
-        Assert::oneOf($combiningFactor, CombiningFactor::toArray());
-        $this->field = $field;
-        $this->value = $value;
-        $this->combiningFactor = $combiningFactor;
-        $this->options = $options;
-    }
-
-    /**
-     * @return string
-     */
-    public function getCombiningFactor(): string
-    {
-        return $this->combiningFactor;
-    }
-
-    /**
-     * @return string
-     */
-    public function getField(): string
-    {
-        return $this->field;
-    }
-
-    /**
-     * @return mixed
-     */
-    public function getValue()
-    {
-        return $this->value;
-    }
-
-    /**
-     * @inheritdoc
-     */
-    public function formatForQuery(): array
-    {
-        return [
-                'match' => [
-                    $this->getField() =>  array_merge([
-                        'query' => $this->getValue()
-                    ], $this->options)
-                ]
-            ];
-    }
-
-
 }

--- a/src/Query/MultiMatchQuery.php
+++ b/src/Query/MultiMatchQuery.php
@@ -3,62 +3,10 @@
 
 namespace Novaway\ElasticsearchClient\Query;
 
-
-use Webmozart\Assert\Assert;
-
-class MultiMatchQuery implements Query
+/**
+ *
+ * @deprecated use Novaway\ElasticsearchClient\Query\FullText\MultiMatchQuery instead
+ */
+class MultiMatchQuery extends \Novaway\ElasticsearchClient\Query\FullText\MultiMatchQuery
 {
-    const BEST_FIELDS = 'best_fields';
-    const MOST_FIELDS = 'most_fields';
-    const CROSS_FIELDS = 'cross_fields';
-    const PHRASE = 'phrase';
-    const PHRASE_PREFIX = 'phrase_prefix';
-    /** @var string */
-    private $value;
-    /** @var string[]|BoostableField[] */
-    private $fields;
-    /** @var array */
-    private $options;
-    /** @var string */
-    private $combiningFactor;
-
-    /**
-     * @param string $value the query value to search for
-     * @param array $fields the fields to search for. Should either contain strings or BoostableField
-     * @param string $combiningFactor the combining factor
-     * @param array $options additional options
-     */
-    public function __construct(string $value, array $fields, string $combiningFactor = CombiningFactor::SHOULD,array $options = [])
-    {
-        Assert::oneOf($combiningFactor, CombiningFactor::toArray());
-        $fields = array_map(function($field) {
-            if (!($field instanceof BoostableField || is_string($field))) {
-                throw new \Exception('$fields array should either contain strings or BoostableField');
-            };
-            // if the field is a string, the cast doesn't do anything
-            // if the field is a BoostableField, it willl be cast as string using the __toString method
-            return (string)$field;
-        }, $fields);
-
-        $this->value = $value;
-        $this->fields = $fields;
-        $this->options = $options;
-        $this->combiningFactor = $combiningFactor;
-    }
-    
-    public function formatForQuery(): array
-    {
-        return [
-            'multi_match' =>
-                array_merge([
-                    'query' => $this->value,
-                    'fields' => $this->fields
-                ], $this->options)
-        ];
-    }
-
-    public function getCombiningFactor(): string
-    {
-        return $this->combiningFactor;
-    }
 }

--- a/src/Query/PrefixQuery.php
+++ b/src/Query/PrefixQuery.php
@@ -3,65 +3,10 @@
 
 namespace Novaway\ElasticsearchClient\Query;
 
-
-use Webmozart\Assert\Assert;
-
-class PrefixQuery implements Query
+/**
+ *
+ * @deprecated use Novaway\ElasticsearchClient\Query\Term\PrefixQuery instead
+ */
+class PrefixQuery extends \Novaway\ElasticsearchClient\Query\Term\PrefixQuery
 {
-    /** @var string */
-    private $combiningFactor;
-    /** @var string */
-    private $field;
-    /** @var mixed */
-    private $value;
-    /** @var float */
-    private $boost;
-
-    public function __construct(string $field, $value, string $combiningFactor = CombiningFactor::MUST, float $boost = 1)
-    {
-        Assert::oneOf($combiningFactor, CombiningFactor::toArray());
-        $this->field = $field;
-        $this->value = $value;
-        $this->combiningFactor = $combiningFactor;
-        $this->boost = $boost;
-    }
-
-    /**
-     * @return string
-     */
-    public function getCombiningFactor(): string
-    {
-        return $this->combiningFactor;
-    }
-
-    /**
-     * @return string
-     */
-    public function getField(): string
-    {
-        return $this->field;
-    }
-
-    /**
-     * @return mixed
-     */
-    public function getValue()
-    {
-        return $this->value;
-    }
-
-    /**
-     * @inheritdoc
-     */
-    public function formatForQuery(): array
-    {
-        return [
-            'prefix' => [
-                $this->getField() =>  [
-                    'value' => $this->getValue(),
-                    'boost' => $this->boost
-                ]
-            ]
-        ];
-    }
 }

--- a/src/Query/QueryBuilder.php
+++ b/src/Query/QueryBuilder.php
@@ -5,10 +5,11 @@ namespace Novaway\ElasticsearchClient\Query;
 use Novaway\ElasticsearchClient\Aggregation\Aggregation;
 use Novaway\ElasticsearchClient\Clause;
 use Novaway\ElasticsearchClient\Filter\Filter;
-use Novaway\ElasticsearchClient\Score\FunctionScore;
+use Novaway\ElasticsearchClient\Query\Compound\FunctionScore;
 use Novaway\ElasticsearchClient\Score\FunctionScoreOptions;
 use Novaway\ElasticsearchClient\Script\ScriptField;
 use Novaway\ElasticsearchClient\Score\ScriptScore;
+use Novaway\ElasticsearchClient\Query\FullText\MatchQuery;
 
 class QueryBuilder
 {

--- a/src/Query/Term/ExistsQuery.php
+++ b/src/Query/Term/ExistsQuery.php
@@ -1,0 +1,38 @@
+<?php
+
+
+namespace Novaway\ElasticsearchClient\Query\Term;
+
+use Novaway\ElasticsearchClient\Filter\Filter;
+use Novaway\ElasticsearchClient\Query\CombiningFactor;
+use Novaway\ElasticsearchClient\Query\Query;
+use Webmozart\Assert\Assert;
+
+class ExistsQuery implements Filter, Query
+{
+    /** @var string */
+    protected $property;
+    /** @var string */
+    private $combiningFactor;
+
+    public function __construct(string $property, $combiningFactor = CombiningFactor::FILTER)
+    {
+        Assert::oneOf($combiningFactor, CombiningFactor::toArray());
+        $this->property = $property;
+        $this->combiningFactor = $combiningFactor;
+    }
+
+    public function getCombiningFactor(): string
+    {
+        return $this->combiningFactor;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function formatForQuery(): array
+    {
+        return ['exists' => [ 'field' => $this->property]];
+    }
+
+}

--- a/src/Query/Term/InArrayQuery.php
+++ b/src/Query/Term/InArrayQuery.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Novaway\ElasticsearchClient\Query\Term;
+
+use Novaway\ElasticsearchClient\Filter\Filter;
+use Novaway\ElasticsearchClient\Query\CombiningFactor;
+use Novaway\ElasticsearchClient\Query\Query;
+use Webmozart\Assert\Assert;
+
+class InArrayQuery implements Filter, Query
+{
+    /** @var string */
+    private $property;
+    /** @var array */
+    private $values;
+    /** @var string */
+    private $combiningFactor;
+
+    public function __construct(string $property, array $values, string $combiningFactor = CombiningFactor::FILTER)
+    {
+        Assert::oneOf($combiningFactor, CombiningFactor::toArray());
+        $this->property = $property;
+        $this->values = $values;
+        $this->combiningFactor = $combiningFactor;
+    }
+
+    /**
+     * @return string
+     */
+    public function getCombiningFactor(): string
+    {
+        return $this->combiningFactor;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function formatForQuery(): array
+    {
+        return [
+            'bool' => [
+                'should' => array_map(function ($value) {
+                    $matchFilter = new TermQuery($this->property, $value);
+                    return $matchFilter->formatForQuery();
+                }, $this->values)
+            ]
+        ];
+    }
+}

--- a/src/Query/Term/PrefixQuery.php
+++ b/src/Query/Term/PrefixQuery.php
@@ -1,14 +1,14 @@
 <?php
 
-namespace Novaway\ElasticsearchClient\Query\FullText;
 
-//https://www.elastic.co/guide/en/elasticsearch/reference/5.6/query-dsl-match-query.html
+namespace Novaway\ElasticsearchClient\Query\Term;
+
+
 use Novaway\ElasticsearchClient\Query\CombiningFactor;
 use Novaway\ElasticsearchClient\Query\Query;
 use Webmozart\Assert\Assert;
 
-
-class MatchQuery implements Query
+class PrefixQuery implements Query
 {
     /** @var string */
     private $combiningFactor;
@@ -16,16 +16,16 @@ class MatchQuery implements Query
     private $field;
     /** @var mixed */
     private $value;
-    /** @var array  */
-    private $options;
+    /** @var float */
+    private $boost;
 
-    public function __construct(string $field, $value, string $combiningFactor = CombiningFactor::MUST, array $options = ['operator' => 'AND'])
+    public function __construct(string $field, $value, string $combiningFactor = CombiningFactor::MUST, float $boost = 1)
     {
         Assert::oneOf($combiningFactor, CombiningFactor::toArray());
         $this->field = $field;
         $this->value = $value;
         $this->combiningFactor = $combiningFactor;
-        $this->options = $options;
+        $this->boost = $boost;
     }
 
     /**
@@ -58,13 +58,12 @@ class MatchQuery implements Query
     public function formatForQuery(): array
     {
         return [
-                'match' => [
-                    $this->getField() =>  array_merge([
-                        'query' => $this->getValue()
-                    ], $this->options)
+            'prefix' => [
+                $this->getField() =>  [
+                    'value' => $this->getValue(),
+                    'boost' => $this->boost
                 ]
-            ];
+            ]
+        ];
     }
-
-
 }

--- a/src/Query/Term/RangeQuery.php
+++ b/src/Query/Term/RangeQuery.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace Novaway\ElasticsearchClient\Query\Term;
+
+use Novaway\ElasticsearchClient\Filter\Filter;
+use Novaway\ElasticsearchClient\Query\CombiningFactor;
+use Novaway\ElasticsearchClient\Query\Query;
+use Webmozart\Assert\Assert;
+
+class RangeQuery implements Filter, Query
+{
+    const GREATER_THAN_OPERATOR = 'gt';
+    const GREATER_THAN_OR_EQUAL_OPERATOR = 'gte';
+    const LESS_THAN_OPERATOR = 'lt';
+    const LESS_THAN_OR_EQUAL_OPERATOR = 'lte';
+
+    /** @var string */
+    private $property;
+    /** @var mixed */
+    private $value;
+    /** @var array */
+    private $operator;
+    /** @var string */
+    private $combiningFactor;
+
+    public function __construct(string $property, $value, $operator, string $combiningFactor = CombiningFactor::FILTER)
+    {
+        Assert::oneOf($combiningFactor, CombiningFactor::toArray());
+
+        if(is_array($value) && !is_array($operator)) {
+            throw new \InvalidArgumentException("Operator should be an array when range filter value is an array");
+        }
+        if(!is_array($value) && is_array($operator)) {
+            throw new \InvalidArgumentException("Operator can't be an array if range filter is not an array");
+        }
+        if(is_array($value) && is_array($operator) && count($value) !== count($operator)) {
+            throw new \InvalidArgumentException("Number of provided operator does not match number of provided values");
+        }
+
+        $this->property = $property;
+        $this->value = is_array($value) ? $value : [$value];
+        $this->operator = is_array($operator) ? $operator : [$operator];
+        $this->combiningFactor = $combiningFactor;
+    }
+
+    /**
+     * @return string
+     */
+    public function getCombiningFactor(): string
+    {
+        return $this->combiningFactor;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function formatForQuery(): array
+    {
+        $rangeConditions = [];
+
+        $valueCount = count($this->value);
+        for ($i = 0; $i < $valueCount; $i++){
+            $rangeConditions[] = [$this->operator[$i] => $this->value[$i]];
+        }
+
+        return [
+            'range' => [
+                $this->property => $rangeConditions
+            ]
+        ];
+    }
+}

--- a/src/Query/Term/TermQuery.php
+++ b/src/Query/Term/TermQuery.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Novaway\ElasticsearchClient\Query\Term;
+
+use Novaway\ElasticsearchClient\Filter\Filter;
+use Novaway\ElasticsearchClient\Query\CombiningFactor;
+use Novaway\ElasticsearchClient\Query\Query;
+use Webmozart\Assert\Assert;
+
+class TermQuery implements Filter, Query
+{
+    /** @var string */
+    private $property;
+    /** @var string */
+    private $value;
+    /** @var string */
+    private $combiningFactor;
+    /** @var float */
+    private $boost;
+
+    public function __construct(string $property, $value, string $combiningFactor = CombiningFactor::FILTER, float $boost = 1)
+    {
+        Assert::oneOf($combiningFactor, CombiningFactor::toArray());
+        $this->property = $property;
+        $this->value = $value;
+        $this->combiningFactor = $combiningFactor;
+        $this->boost = $boost;
+    }
+
+    /**
+     * @return string
+     */
+    public function getCombiningFactor(): string
+    {
+        return $this->combiningFactor;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function formatForQuery(): array
+    {
+        return [
+            'term' => [
+                $this->property =>  [
+                    'value' => $this->value,
+                    'boost' => $this->boost
+                ]
+            ]
+        ];
+    }
+}
+

--- a/src/Score/DecayFunctionScore.php
+++ b/src/Score/DecayFunctionScore.php
@@ -3,6 +3,8 @@
 
 namespace Novaway\ElasticsearchClient\Score;
 
+use Novaway\ElasticsearchClient\Query\Compound\FunctionScore as FunctionScore;
+use Webmozart\Assert\Assert;
 
 class DecayFunctionScore implements FunctionScore
 {
@@ -34,9 +36,7 @@ class DecayFunctionScore implements FunctionScore
 
     public function __construct(string $property, string $function, $origin, string $offset, string $scale, array $options = [], float $decay = self::DECAY)
     {
-        if (!in_array($function, self::$availableFunctions)) {
-            throw new \InvalidArgumentException(sprintf("function should be one of %s : %s given", implode("," , self::$availableFunctions), $function));
-        }
+        Assert::oneOf($decay, self::$availableFunctions);
         $this->property = $property;
         $this->function = $function;
         $this->origin = $origin;

--- a/src/Score/DecayFunctionScore.php
+++ b/src/Score/DecayFunctionScore.php
@@ -36,7 +36,7 @@ class DecayFunctionScore implements FunctionScore
 
     public function __construct(string $property, string $function, $origin, string $offset, string $scale, array $options = [], float $decay = self::DECAY)
     {
-        Assert::oneOf($decay, self::$availableFunctions);
+        Assert::oneOf($function, self::$availableFunctions);
         $this->property = $property;
         $this->function = $function;
         $this->origin = $origin;

--- a/src/Score/FunctionScore.php
+++ b/src/Score/FunctionScore.php
@@ -2,12 +2,9 @@
 
 namespace Novaway\ElasticsearchClient\Score;
 
-interface FunctionScore
+/**
+ * @deprecated use Novaway\ElasticsearchClient\Query\Compound\FunctionScore instead
+ */
+interface FunctionScore extends \Novaway\ElasticsearchClient\Query\Compound\FunctionScore
 {
-    /**
-     * Return a JSON formatted representation of the clause, tu use in elasticsearch
-     *
-     * @return array
-     */
-    public function formatForQuery(): array;
 }

--- a/src/Score/RandomScore.php
+++ b/src/Score/RandomScore.php
@@ -2,6 +2,8 @@
 
 namespace Novaway\ElasticsearchClient\Score;
 
+use Novaway\ElasticsearchClient\Query\Compound\FunctionScore as FunctionScore;
+
 class RandomScore implements FunctionScore
 {
     /** @var string */

--- a/src/Score/ScriptScore.php
+++ b/src/Score/ScriptScore.php
@@ -7,6 +7,7 @@ namespace Novaway\ElasticsearchClient\Score;
 use Novaway\ElasticsearchClient\Script\ScriptingLanguage;
 use Novaway\ElasticsearchClient\Script\Traits\ScriptTrait;
 use Webmozart\Assert\Assert;
+use Novaway\ElasticsearchClient\Query\Compound\FunctionScore as FunctionScore;
 
 class ScriptScore implements FunctionScore
 {

--- a/test/unit/Query/Compound/BoolQuery.php
+++ b/test/unit/Query/Compound/BoolQuery.php
@@ -1,0 +1,48 @@
+<?php
+
+
+namespace Test\Unit\Novaway\ElasticsearchClient\Query\Compound;
+
+
+use atoum\test;
+use Novaway\ElasticsearchClient\Query\CombiningFactor;
+use Novaway\ElasticsearchClient\Query\FullText\MatchQuery;
+
+class BoolQuery extends test
+{
+    public function testAddQuery()
+    {
+        $this
+            ->given($this->newTestedInstance())
+            ->if(
+                $this->testedInstance->addClause(new MatchQuery('firstname', 'bruce', CombiningFactor::MUST)),
+                $this->testedInstance->addClause(new MatchQuery('gender', 'male', CombiningFactor::MUST)),
+                $this->testedInstance->addClause(new MatchQuery('lastname', 'wayne', CombiningFactor::MUST_NOT))
+            )
+            ->then
+            ->array($this->testedInstance->formatForQuery())
+            ->isEqualTo([
+                'bool' => [
+                    'must' => [
+                        [
+                            'match' => [
+                                'firstname' => ['query' =>'bruce', 'operator' => 'AND']
+                            ],
+                        ],[
+                            'match' => [
+                                'gender' => ['query' => 'male', 'operator' => 'AND']
+                            ],
+                        ]
+                    ],
+                    'must_not' => [
+                        [
+                            'match' => [
+                                'lastname' => ['query' => 'wayne', 'operator' => 'AND']
+                            ]
+                        ]
+                    ],
+                ]
+            ])
+        ;
+    }
+}

--- a/test/unit/Query/FullText/MultiMatchQuery.php
+++ b/test/unit/Query/FullText/MultiMatchQuery.php
@@ -1,7 +1,7 @@
 <?php
 
 
-namespace Test\Unit\Novaway\ElasticsearchClient\Query;
+namespace Test\Unit\Novaway\ElasticsearchClient\Query\FullText;
 
 
 use atoum\test;

--- a/test/unit/Query/Geo/GeoDistanceQuery.php
+++ b/test/unit/Query/Geo/GeoDistanceQuery.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace Test\Unit\Novaway\ElasticsearchClient\Filter;
+namespace Test\Unit\Novaway\ElasticsearchClient\Query\Geo;
 
 use atoum\test;
 use Novaway\ElasticsearchClient\Query\CombiningFactor;
 
-class GeoDistanceFilter extends test
+class GeoDistanceQuery extends test
 {
     public function testFormat()
     {


### PR DESCRIPTION
As discussed previously, I refactored most of the filters and queries to better match the [documentation](https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl.html)  organisation, and deprecated all the old ones

I updated the tests too, after ensuring they still passed before refactoring, which should be sufficient to prove that the refactoring went smoothly