### PR TITLE
Search after

### DIFF
--- a/src/Query/QueryBuilder.php
+++ b/src/Query/QueryBuilder.php
@@ -44,6 +44,11 @@ class QueryBuilder
     protected $scriptScore;
     /** @var null|FunctionScoreOptions */
     protected $functionsScoreOptions;
+    /**
+     * @var array
+     * https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-search-after.html
+     */
+    protected $searchAfter;
 
     public function __construct($offset = self::DEFAULT_OFFSET, $limit = self::DEFAULT_LIMIT, $minScore = self::DEFAULT_MIN_SCORE)
     {
@@ -54,6 +59,7 @@ class QueryBuilder
         $this->aggregationCollection = [];
         $this->functionScoreCollection = [];
         $this->scriptFieldCollection = [];
+        $this->searchAfter = [];
 
         $this->queryBody['from'] = $offset;
         $this->queryBody['size'] = $limit;
@@ -254,6 +260,16 @@ class QueryBuilder
         $this->functionsScoreOptions = $functionsScoreOptions;
     }
 
+    public function getSearchAfter(): array
+    {
+        return $this->searchAfter;
+    }
+
+    public function setSearchAfter(array $searchAfter)
+    {
+        $this->searchAfter = $searchAfter;
+    }
+
     public function hasNoMatchingQueries(): bool
     {
         $nonFilterQueries = array_filter($this->getClauseCollection(), function (Clause $clause) {
@@ -300,6 +316,10 @@ class QueryBuilder
 
         if ($this->postFilter) {
             $queryBody['post_filter'] = $this->postFilter->formatForQuery();
+        }
+
+        if ($this->searchAfter) {
+            $queryBody['search_after'] = $this->searchAfter;
         }
 
         return array_merge($this->queryBody, $queryBody);

--- a/src/Query/QueryBuilder.php
+++ b/src/Query/QueryBuilder.php
@@ -20,7 +20,10 @@ class QueryBuilder
     /** @var array */
     protected $queryBody;
 
-    /** @var Filter[] */
+    /**
+     * @var Filter[]
+     * @deprecated
+     */
     protected $filterCollection;
     /** @var Clause */
     protected $postFilter;

--- a/test/functional/bootstrap/FeatureContext.php
+++ b/test/functional/bootstrap/FeatureContext.php
@@ -256,6 +256,29 @@ class FeatureContext implements Context
     }
 
     /**
+     * @Given I add sorting on :
+     */
+    public function iAddSortingOn(TableNode $queryTable)
+    {
+        $this->queryBuilder = $this->queryBuilder ?? QueryBuilder::createNew();
+        $queryHash = $queryTable->getHash();
+        foreach ($queryHash as $queryRow) {
+            $this->queryBuilder->addSort($queryRow['field'], $queryRow['order']);
+        }
+    }
+
+    /**
+     * @Given I add search after :
+     */
+    public function iAddSearchAfter(TableNode $queryTable)
+    {
+        $this->queryBuilder = $this->queryBuilder ?? QueryBuilder::createNew();
+        $queryHash = $queryTable->getHash();
+        $this->queryBuilder->setSearchAfter(array_column($queryHash,'sort'));
+    }
+
+
+    /**
      * @Given I build the query with filter :
      * @Given I build a query with filter :
      */
@@ -306,8 +329,9 @@ class FeatureContext implements Context
             $foundCount += in_array($hit['id'], $idList) ? 1 : 0;
         }
 
-        $this->assert->integer($this->result->totalHits())->isEqualTo(count($idList));
-        $this->assert->integer($foundCount)->isEqualTo(count($idList));
+
+        $this->assert->integer(\count($this->result->hits()))->isEqualTo(\count($idList));
+        $this->assert->integer($foundCount)->isEqualTo(\count($idList));
     }
 
     /**

--- a/test/functional/bootstrap/data/config_my_index.yml
+++ b/test/functional/bootstrap/data/config_my_index.yml
@@ -4,6 +4,8 @@ settings:
 mappings:
     _doc:
         properties:
+            id:
+                type: keyword
             first_name:
                 type: text
                 analyzer: standard

--- a/test/functional/features/search.feature
+++ b/test/functional/features/search.feature
@@ -161,6 +161,7 @@ Feature: Search on index
             | first_name        | Diana         | must    |
         When I execute it on the index named "my_index" for type "_doc"
         Then the result should contain exactly ids "[2]"
+
     Scenario: Combining queries and filters inside a Bool Query
         Given I build a should bool query with :
             | field      | value       | condition |
@@ -337,3 +338,15 @@ Feature: Search on index
         And I search cities with a relation "disjoint" to rhône
         When I execute it on the index named "my_geoindex" for type "_doc"
         Then the result should contain exactly ids "[2;3]"
+
+    Scenario: After search
+        Given I add sorting on :
+            | field  | order |
+            |  age   | asc  |
+            |  id   | asc  |
+        And I add search after :
+            | sort  |
+            |  35   |
+            |  5   |
+        When I execute it on the index named "my_index" for type "_doc"
+        Then the result should contain exactly ids "[6;3;2]"


### PR DESCRIPTION
Added support for https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-search-after.html

Very useful when trying to get the previous and next item from a list